### PR TITLE
Update Gatsby config to TypeScript

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,5 +1,9 @@
-module.exports = {
+import type { GatsbyConfig } from 'gatsby';
+
+const config: GatsbyConfig = {
   // Since `gatsby-plugin-typescript` is automatically included in Gatsby you
   // don't need to define it here (just if you need to change the options)
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
Gatsby now supports TypeScript for the config file. This commit updates the config to make use of the GatsbyConfig type.
https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-configts