### PR TITLE
chore: update Gatsby node to Typescript

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,9 +1,0 @@
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-
-exports.onCreateWebpackConfig = ({ actions }) => {
-  actions.setWebpackConfig({
-    resolve: {
-      plugins: [new TsconfigPathsPlugin()],
-    },
-  });
-};

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,0 +1,12 @@
+import type { GatsbyNode } from 'gatsby';
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+
+export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({
+  actions,
+}) => {
+  actions.setWebpackConfig({
+    resolve: {
+      plugins: [new TsconfigPathsPlugin()],
+    },
+  });
+};


### PR DESCRIPTION
Gatsby now supports TypeScript for the gatsby-node.ts file. This commit updates the node config to make use of the GatsbyNode type.
https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-nodets

This PR is somewhat linked to https://github.com/jpedroschmitz/gatsby-starter-ts/pull/503