### PR TITLE
Update requirements with node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Open `http://localhost:8000` with your browser to see the result.
 
 ### Requirements
 
-- Node.js >= 14.17
+- Node.js >= 18
 - pnpm 7
 
 ### Directory Structure


### PR DESCRIPTION
With the release of Gatsby 5, a minimum Node JS version of 18 is required.

https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v4-to-v5/#minimal-nodejs-version-1800